### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Scout Genius™ is a single Flask (Python) monolith for recruitment automation (XML job-feed
+generation, Bullhorn ATS sync, AI candidate vetting, inbound email, public application forms).
+Everything runs in one process (`main:app`); background jobs run in-process via APScheduler.
+There is no separate frontend build — templates are server-rendered Jinja2 + Bootstrap.
+
+Standard install/run commands live in `README.md`, `.github/workflows/test.yml`, `railway.toml`,
+and `scripts/post-merge.sh`. The notes below only capture what is non-obvious.
+
+### Environment / dependencies
+- The update script installs into a project virtualenv at `.venv`. Always run Python via
+  `.venv/bin/python` / `.venv/bin/gunicorn` / `.venv/bin/pytest`.
+- `requirements.txt` is missing three runtime deps that the app imports (`matplotlib` is imported
+  at module load by `reports/generate_perf_report.py`, so the app will NOT boot without it;
+  `pandas` and `openpyxl` back the Excel/report features). The update script installs all three
+  in addition to `requirements.txt`. `pyproject.toml`/`uv.lock` list the full set if you need it.
+
+### Running the app (development)
+- You MUST set `APP_ENV=development` (or `ENVIRONMENT=development`). With the default (production)
+  env and an empty database, boot HARD-FAILS: the fresh-prod-DB seed guard raises
+  `FreshProductionDatabaseError` and production seeding also demands `BULLHORN_*` secrets.
+- No `DATABASE_URL` → the app falls back to SQLite at `instance/fallback.db`. On boot it runs
+  `db.create_all()` + idempotent seeding, which creates all ~63 tables and a dev admin user.
+  No manual migration/seed step is needed for local dev (Alembic targets Postgres only).
+- Dev admin credentials: username `admin`, password `admin123` (dev fallback from
+  `seeding/config.py`; override with `ADMIN_PASSWORD`).
+- Run: `APP_ENV=development SESSION_SECRET=dev .venv/bin/gunicorn --bind 0.0.0.0:5000 --workers 1 --timeout 300 main:app`
+  (single worker keeps the APScheduler lock simple). `python main.py` also works (dev server, default port 5001).
+- Missing external creds (Bullhorn/OpenAI/SendGrid/Microsoft Graph) are expected: those paths
+  degrade gracefully and the scheduler logs auth errors without crashing.
+
+### Browser login gotcha (HTTPS required)
+- `SESSION_COOKIE_SECURE=True` is hardcoded (`extensions.py`), so the session cookie is only sent
+  over HTTPS. Logging in through a browser over plain `http://localhost` will silently fail to
+  persist the session (you bounce back to `/login`). To test the UI, run gunicorn with TLS, e.g.
+  add `--certfile <cert> --keyfile <key>` (a self-signed cert is fine) and use `https://localhost:5000`.
+- CSRF (Flask-WTF) also does strict `Referer` checking on HTTPS POSTs. Browsers send `Referer`
+  automatically; a scripted client must send a matching `Referer` header (and fetch the
+  `csrf_token` from the login form) or POSTs return HTTP 400.
+
+### Tests / lint
+- Run tests per-file/module (e.g. `.venv/bin/python -m pytest tests/test_auth.py`). Running the
+  whole `tests/` suite at once produces ~180 spurious failures/errors: the session-scoped Flask app
+  shares an in-memory rate limiter, so the many `/login` POSTs across tests trip the 20/min login
+  limit and return HTTP 429. Individual files pass. A few tests (e.g. `test_embedding_ab_shadow.py`)
+  also depend on the `SHADOW_LOGGING_DISABLED` env var and fail unless it is set to `false`.
+- No linter is configured in this repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Scout Genius™ Flask app and captures durable, non-obvious setup guidance for future Cloud Agents in a new `AGENTS.md`.

No application code was changed — only `AGENTS.md` was added.

### Environment setup performed
- Python virtualenv at `.venv` (gitignored), installed from `requirements.txt`.
- Installed 3 runtime deps missing from `requirements.txt` but required by the app: `matplotlib` (imported at module load by `reports/generate_perf_report.py` — app won't boot without it), plus `pandas` and `openpyxl` (report/Excel features). These are present in `pyproject.toml`/`uv.lock`.
- Ran the app in dev mode via gunicorn with the SQLite fallback DB (`APP_ENV=development`, no `DATABASE_URL`); tables + dev admin auto-seed on boot.

### Key non-obvious findings (documented in AGENTS.md)
- Must set `APP_ENV=development`, else the fresh-prod-DB seed guard hard-fails boot on an empty DB.
- `SESSION_COOKIE_SECURE=True` is hardcoded → browser login requires HTTPS (used a self-signed cert for the demo). Flask-WTF also does strict `Referer` checks on HTTPS POSTs.
- The full `pytest tests/` run yields ~180 spurious failures because the session-scoped app shares an in-memory rate limiter and the many `/login` POSTs trip a 429; individual files pass. No linter is configured.

### Verification
- Health endpoint returns healthy (DB connected, scheduler running).
- `pytest` passes per-file (1803 tests pass in a single full run; remaining failures are the rate-limit/env-var artifacts noted above).
- Browser hello-world: logged in as `admin`, navigated to Inbound Config, changed the notification email, and saved successfully (persisted to the DB).

Please merge the AGENTS.md updates so future agents remember these setup caveats next time.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b31cca-533a-4b5b-9995-5a4fcbf74de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b31cca-533a-4b5b-9995-5a4fcbf74de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

