### PR TITLE
Cover native Indeed Apply in Scout Screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,10 @@ Check dashboard for automation status:
 
 ## 📈 Recent Major Updates
 
+### August 2026: Indeed native Apply Scout Screening coverage
+- **Problem**: Native Indeed Apply (Plan B) creates Bullhorn candidates as **New Lead + Unassigned + source Indeed** with a JobSubmission, but never creates a ParsedEmail and never sets status to Online Applicant — so Scout’s detectors never saw them (LinkedIn Job Board email inbound continued to screen normally).
+- **Fix**: `detect_indeed_applicants` in `screening/detection.py` — source-based Lucene search (`Indeed` / `Indeed Job Board`), JobSubmission gate, Unassigned-eligible human-owner skip, merged into the 1-minute vetting cycle (same pattern as Matador).
+
 ### October 2025: Database-Backed Reference Number Preservation ✨
 - **Problem Identified**: Live XML URL returns 403 Forbidden, causing reference number reversion
 - **Solution Implemented**: JobReferenceNumber database table for persistent storage
@@ -490,5 +494,5 @@ Access health endpoints for status checks:
 
 ---
 
-**Last Updated**: October 2025  
-**Version**: 2.0 (Database-Backed Reference Preservation)
+**Last Updated**: August 2026  
+**Version**: 2.1 (Indeed native Apply Scout Screening coverage)

--- a/candidate_vetting_service/cycle.py
+++ b/candidate_vetting_service/cycle.py
@@ -106,6 +106,20 @@ class VettingCycleMixin:
                 else:
                     summary['detection_method'] = f"{summary['detection_method']}+matador"
 
+            # Native Indeed Apply (Plan B / Indeed Apply) lands as New Lead +
+            # source Indeed outside ParsedEmail and Online Applicant detectors.
+            indeed_candidates = self.detect_indeed_applicants(since_minutes=120)
+            if indeed_candidates:
+                logger.info(f"🟢 Adding {len(indeed_candidates)} Indeed applicants to vetting queue")
+
+                existing_ids = {c.get('id') for c in candidates}
+                for indeed_candidate in indeed_candidates:
+                    if indeed_candidate.get('id') not in existing_ids:
+                        candidates.append(indeed_candidate)
+                        existing_ids.add(indeed_candidate.get('id'))
+
+                summary['detection_method'] = f"{summary['detection_method']}+indeed"
+
             pando_note_candidates = self.detect_pandologic_note_candidates(since_minutes=10)
             if pando_note_candidates:
                 logger.info(

--- a/docs/AI_Candidate_Vetting_Module.md
+++ b/docs/AI_Candidate_Vetting_Module.md
@@ -12,7 +12,8 @@ The AI Candidate Vetting Module is an advanced feature of Scout Genius™ that a
 - **ParsedEmail-Based Detection**: Captures ALL inbound applicants by tracking the `vetted_at` column in the ParsedEmail table
 - **Both New and Existing Candidates**: Processes applications whether the candidate is new to Bullhorn or already exists with an updated resume
 - **Fallback Detection**: Legacy "Online Applicant" status search as backup for candidates entering through other channels
-
+- **Owner-based detectors**: Pandologic API and Matador API (corporate website New Lead) applicants
+- **Indeed native Apply detector** (Aug 2026): Source-based discovery for `source:Indeed` / `Indeed Job Board` candidates that land as **New Lead + Unassigned** via Bullhorn↔Indeed Apply (outside email inbound). Requires a JobSubmission (applied, not sourced).
 ### 2. Intelligent Resume Analysis
 - **Resume Extraction**: Downloads resume files (PDF, DOCX, DOC, TXT) from candidate profiles in Bullhorn
 - **Three-Layer PDF Processing** (implemented 2026-01-30):
@@ -71,6 +72,8 @@ The AI Candidate Vetting Module is an advanced feature of Scout Genius™ that a
 │  2. DETECT UNVETTED APPLICATIONS                                    │
 │     └─> Query ParsedEmail where vetted_at IS NULL                   │
 │     └─> Fallback: Search Bullhorn for "Online Applicant" status     │
+│     └─> Always merge: Pandologic / Matador / Indeed native Apply    │
+│         / Pandologic-note / pending auditor revets                  │
 │                                                                     │
 │  3. FOR EACH CANDIDATE (up to batch_size):                          │
 │     a. Download resume from Bullhorn                                │
@@ -321,6 +324,7 @@ Each entry includes:
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-08-03 | 1.2 | Added detect_indeed_applicants for native Indeed Apply New Lead coverage (source-based + JobSubmission gate) |
 | 2026-01-30 | 1.1 | Enhanced resume formatting with three-layer PDF processing (PyMuPDF + deterministic text normalization + GPT-4o AI formatting) for proper HTML display in Bullhorn |
 | 2026-01-30 | 1.0 | Initial release with ParsedEmail detection, GPT-4o matching, CC-based notifications |
 | 2026-01-28 | 0.9 | Fixed note creation with commentingPerson ID |

--- a/screening/detection.py
+++ b/screening/detection.py
@@ -8,6 +8,7 @@ Contains:
   - detect_pandologic_candidates: Finds Pandologic API candidates (owner-based)
   - detect_pandologic_note_candidates: Finds re-applicants via Pandologic API notes
   - detect_matador_candidates: Finds Matador API candidates (corporate website submissions)
+  - detect_indeed_applicants: Finds native Indeed Apply candidates (source-based New Lead)
   - detect_unvetted_applications: Primary detection via ParsedEmail records
   - _resolve_pandologic_user_id: Resolves and caches Pandologic CorporateUser ID
 
@@ -400,6 +401,166 @@ class CandidateDetectionMixin(CandidateDeduplicationMixin, CandidateDataAccessMi
             
         except Exception as e:
             logger.error(f"Error detecting Matador candidates: {str(e)}")
+            return []
+
+    def detect_indeed_applicants(self, since_minutes: int = 120) -> List[Dict]:
+        """
+        Find candidates from native Indeed Apply that haven't been vetted recently.
+
+        Indeed Plan B (Bullhorn JobBoard CFC publish) and Indeed Apply create
+        Candidate + JobSubmission records directly in Bullhorn with
+        source='Indeed' (or 'Indeed Job Board') and status='New Lead', often
+        owned by Unassigned. They bypass ParsedEmail inbound entirely and do
+        not match status:"Online Applicant", so detect_new_applicants misses
+        them — same discovery gap Matador solves via owner-based detection.
+
+        Uses source-based Lucene search + JobSubmission gate (applied, not
+        merely sourced). Job-aware dedup via _should_skip_candidate.
+
+        Default lookback is 120 minutes (wider than Matador's last-run-only
+        window) so briefly delayed discovery still catches native applies
+        even when the sliding last-run watermark has already advanced.
+
+        Args:
+            since_minutes: Minimum lookback window in minutes (also used as
+                the floor when a last-run timestamp exists).
+
+        Returns:
+            List of candidate dictionaries from Bullhorn, each enriched with
+            `_applied_job_id` / `_applied_job_title` when a JobSubmission is
+            found.
+        """
+        bullhorn = self._get_bullhorn_service()
+        if not bullhorn:
+            return []
+
+        if not bullhorn.authenticate():
+            logger.error("Failed to authenticate with Bullhorn for Indeed detection")
+            return []
+
+        try:
+            floor = datetime.utcnow() - timedelta(minutes=max(since_minutes, 60))
+            last_run = self._get_last_run_timestamp()
+            # Look at least `floor` back so native Indeed applies are not lost
+            # when last_run advances every minute without an Indeed detector.
+            if last_run:
+                since_time = min(last_run, floor)
+            else:
+                since_time = floor
+
+            since_timestamp = int(since_time.timestamp() * 1000)
+
+            # Native Indeed Apply uses source "Indeed"; JobPulse inbound
+            # normalizes to "Indeed Job Board". Match both.
+            url = f"{bullhorn.base_url}search/Candidate"
+            params = {
+                'query': (
+                    f'(source:Indeed OR source:"Indeed Job Board") '
+                    f'AND dateLastModified:[{since_timestamp} TO *]'
+                ),
+                'fields': (
+                    'id,firstName,lastName,email,phone,status,dateAdded,'
+                    'dateLastModified,source,occupation,description,'
+                    'address(address1,city,state,countryName),owner(id,name)'
+                ),
+                'count': 50,
+                'sort': '-dateLastModified',
+                'BhRestToken': bullhorn.rest_token,
+            }
+
+            response = bullhorn.session.get(url, params=params, timeout=30)
+
+            if response.status_code != 200:
+                logger.error(
+                    f"Failed to search for Indeed applicants: {response.status_code}"
+                )
+                return []
+
+            data = response.json()
+            candidates = data.get('data', [])
+
+            logger.info(f"🟢 Indeed: Found {len(candidates)} candidates since {since_time}")
+
+            # Human-owner skip: Unassigned (id=1) must remain eligible — native
+            # Indeed Apply lands Unassigned. Treat missing owner and Unassigned
+            # as not human-owned; skip only real recruiter owners when enabled.
+            skip_human_owned = _screening_skip_human_owned()
+            api_user_ids = (
+                _parse_api_user_ids_for_screening() if skip_human_owned else []
+            )
+            human_owned_skipped = 0
+
+            new_candidates = []
+            for candidate in candidates:
+                candidate_id = candidate.get('id')
+                if not candidate_id:
+                    continue
+
+                if skip_human_owned and api_user_ids:
+                    owner = candidate.get('owner') or {}
+                    owner_id = owner.get('id')
+                    is_unassigned = (
+                        owner_id is None
+                        or (isinstance(owner_id, int) and owner_id == 1)
+                        or str(owner_id) == '1'
+                        or 'unassigned' in str(owner.get('name') or '').lower()
+                    )
+                    if (
+                        not is_unassigned
+                        and _is_human_owned(candidate, api_user_ids)
+                    ):
+                        logger.info(
+                            f"Indeed candidate {candidate_id} "
+                            f"({candidate.get('firstName')} {candidate.get('lastName')}) "
+                            f"has human owner (id={owner_id}, "
+                            f"name={owner.get('name', '?')}); skipping re-screen"
+                        )
+                        human_owned_skipped += 1
+                        continue
+
+                applied_job_id, applied_job_title, _lookup_ok = (
+                    self._fetch_latest_job_submission(bullhorn, candidate_id)
+                )
+
+                # Job submission gate: skip sourced-only (no application).
+                if _lookup_ok and applied_job_id is None:
+                    logger.debug(
+                        f"Indeed candidate {candidate_id} skipped — "
+                        f"no JobSubmission found (sourced, not applied)"
+                    )
+                    continue
+
+                if applied_job_id is not None:
+                    candidate['_applied_job_id'] = applied_job_id
+                    candidate['_applied_job_title'] = applied_job_title or ''
+
+                if self._should_skip_candidate(
+                    candidate_id, applied_job_id, bullhorn=bullhorn
+                ):
+                    logger.debug(
+                        f"Indeed candidate {candidate_id} skipped by job-aware dedup "
+                        f"(applied_job={applied_job_id})"
+                    )
+                else:
+                    new_candidates.append(candidate)
+                    job_info = f" for job {applied_job_id}" if applied_job_id else ""
+                    logger.info(
+                        f"🟢 Indeed applicant detected: "
+                        f"{candidate.get('firstName')} {candidate.get('lastName')} "
+                        f"(ID: {candidate_id}{job_info}, "
+                        f"source={candidate.get('source')!r}, "
+                        f"status={candidate.get('status')!r})"
+                    )
+
+            logger.info(
+                f"🟢 Indeed: {len(new_candidates)} candidates to vet out of "
+                f"{len(candidates)} total "
+                f"({human_owned_skipped} skipped — human-owned)"
+            )
+            return new_candidates
+
+        except Exception as e:
+            logger.error(f"Error detecting Indeed applicants: {str(e)}")
             return []
 
     def _resolve_pandologic_user_id(self, bullhorn) -> Optional[int]:

--- a/tests/test_cvs_errors.py
+++ b/tests/test_cvs_errors.py
@@ -328,6 +328,63 @@ class TestMatadorMerge:
             assert 'matador' in result['detection_method']
             _release_lock(app)
 
+
+# ===========================================================================
+# 5b. Indeed native Apply candidate detection merge
+# ===========================================================================
+class TestIndeedMerge:
+
+    def test_indeed_candidates_merged_without_dupes(self, app):
+        """Indeed applicants merge with parsed_email candidates and dedupe by ID."""
+        _set_vetting_enabled(app, True)
+        cvs = _make_cvs()
+
+        with app.app_context():
+            _release_lock(app)
+            email_candidates = [{'id': 910, 'firstName': 'Email', 'lastName': 'One'}]
+            indeed_candidates = [
+                {'id': 910, 'firstName': 'Email', 'lastName': 'One'},  # duplicate
+                {'id': 911, 'firstName': 'Indeed', 'lastName': 'New'},
+            ]
+
+            with patch.object(cvs, 'detect_unvetted_applications', return_value=email_candidates):
+                with patch.object(cvs, 'detect_pandologic_candidates', return_value=[]):
+                    with patch.object(cvs, 'detect_matador_candidates', return_value=[]):
+                        with patch.object(cvs, 'detect_indeed_applicants', return_value=indeed_candidates):
+                            with patch.object(cvs, 'process_candidate', return_value=None):
+                                result = cvs.run_vetting_cycle()
+
+            assert result['candidates_detected'] == 2
+            assert 'indeed' in result['detection_method']
+            _release_lock(app)
+
+    def test_indeed_only_cycle_uses_indeed_method(self, app):
+        """If only Indeed candidates are present, detection_method flags it."""
+        _set_vetting_enabled(app, True)
+        cvs = _make_cvs()
+
+        with app.app_context():
+            _release_lock(app)
+            indeed_candidates = [{'id': 912, 'firstName': 'I', 'lastName': 'Only'}]
+
+            with patch.object(cvs, 'detect_unvetted_applications', return_value=[]):
+                with patch.object(cvs, 'detect_new_applicants', return_value=[]):
+                    with patch.object(cvs, 'detect_pandologic_candidates', return_value=[]):
+                        with patch.object(cvs, 'detect_matador_candidates', return_value=[]):
+                            with patch.object(cvs, 'detect_indeed_applicants', return_value=indeed_candidates):
+                                with patch.object(cvs, 'process_candidate', return_value=None):
+                                    result = cvs.run_vetting_cycle()
+
+            assert result['candidates_detected'] == 1
+            assert 'indeed' in result['detection_method']
+            _release_lock(app)
+
+
+# ===========================================================================
+# 5c. Matador Lucene query shape
+# ===========================================================================
+class TestMatadorQuery:
+
     def test_matador_detection_uses_owner_filter(self, app):
         """detect_matador_candidates queries Bullhorn with owner.name:'Matador API'."""
         from unittest.mock import MagicMock

--- a/tests/test_returning_applicant.py
+++ b/tests/test_returning_applicant.py
@@ -703,8 +703,8 @@ class TestPreNoteDuplicateSafeguard:
 
 class TestSubmissionGate:
     """
-    Unit tests for the job-submission gate added to detect_pandologic_candidates
-    and detect_matador_candidates.
+    Unit tests for the job-submission gate added to detect_pandologic_candidates,
+    detect_matador_candidates, and detect_indeed_applicants.
 
     Gate rules:
       - lookup OK  + no submission  → candidate skipped (sourced, not applied)
@@ -863,3 +863,104 @@ class TestSubmissionGate:
 
         assert len(result) == 1
         assert result[0]['_applied_job_id'] == 43719
+
+    def _make_indeed_bullhorn(self, candidate_id=8101, owner_id=1, owner_name='Unassigned User'):
+        """Bullhorn mock returning one Indeed New Lead candidate."""
+        bh = MagicMock()
+        bh.authenticate.return_value = True
+        bh.base_url = 'https://rest.bullhorn.test/'
+        bh.rest_token = 'token123'
+        bh.user_id = 1147490
+
+        candidate_payload = {
+            'id': candidate_id,
+            'firstName': 'Indeed',
+            'lastName': 'Applicant',
+            'email': 'indeed@example.com',
+            'status': 'New Lead',
+            'dateAdded': 1700000000000,
+            'dateLastModified': 1700000000000,
+            'source': 'Indeed',
+            'occupation': 'Project Engineer',
+            'description': '',
+            'address': {},
+            'owner': {'id': owner_id, 'name': owner_name},
+        }
+        search_response = MagicMock()
+        search_response.status_code = 200
+        search_response.json.return_value = {'data': [candidate_payload]}
+        bh.session.get.return_value = search_response
+        return bh
+
+    def test_indeed_no_submission_skipped(self, app):
+        """Indeed candidate with lookup OK but no JobSubmission is excluded."""
+        svc = self._make_service()
+        bh = self._make_indeed_bullhorn()
+
+        with patch.object(svc, '_get_bullhorn_service', return_value=bh), \
+             patch.object(svc, '_get_last_run_timestamp', return_value=None), \
+             patch.object(svc, '_fetch_latest_job_submission',
+                          return_value=(None, None, True)), \
+             patch.object(svc, '_should_skip_candidate', return_value=False), \
+             patch('screening.detection._screening_skip_human_owned', return_value=False):
+            with app.app_context():
+                result = svc.detect_indeed_applicants()
+
+        assert result == []
+
+    def test_indeed_lookup_failure_passes_through(self, app):
+        """Indeed candidate with failed JobSubmission lookup passes through."""
+        svc = self._make_service()
+        bh = self._make_indeed_bullhorn()
+
+        with patch.object(svc, '_get_bullhorn_service', return_value=bh), \
+             patch.object(svc, '_get_last_run_timestamp', return_value=None), \
+             patch.object(svc, '_fetch_latest_job_submission',
+                          return_value=(None, None, False)), \
+             patch.object(svc, '_should_skip_candidate', return_value=False), \
+             patch('screening.detection._screening_skip_human_owned', return_value=False):
+            with app.app_context():
+                result = svc.detect_indeed_applicants()
+
+        assert len(result) == 1
+
+    def test_indeed_with_submission_unassigned_passes_through(self, app):
+        """Unassigned Indeed New Lead with a JobSubmission is included."""
+        svc = self._make_service()
+        bh = self._make_indeed_bullhorn()
+
+        with patch.object(svc, '_get_bullhorn_service', return_value=bh), \
+             patch.object(svc, '_get_last_run_timestamp', return_value=None), \
+             patch.object(svc, '_fetch_latest_job_submission',
+                          return_value=(35593, 'Structural Engineer', True)), \
+             patch.object(svc, '_should_skip_candidate', return_value=False), \
+             patch('screening.detection._screening_skip_human_owned', return_value=True), \
+             patch('screening.detection._parse_api_user_ids_for_screening',
+                   return_value=[1147490]):
+            with app.app_context():
+                result = svc.detect_indeed_applicants()
+
+        assert len(result) == 1
+        assert result[0]['_applied_job_id'] == 35593
+        # Query must target Indeed sources
+        called_params = bh.session.get.call_args[1]['params']
+        assert 'source:Indeed' in called_params['query']
+        assert 'Indeed Job Board' in called_params['query']
+
+    def test_indeed_human_owned_skipped_when_enabled(self, app):
+        """Recruiter-owned Indeed candidates are skipped when human-owner skip is on."""
+        svc = self._make_service()
+        bh = self._make_indeed_bullhorn(owner_id=99999, owner_name='Jane Recruiter')
+
+        with patch.object(svc, '_get_bullhorn_service', return_value=bh), \
+             patch.object(svc, '_get_last_run_timestamp', return_value=None), \
+             patch.object(svc, '_fetch_latest_job_submission',
+                          return_value=(35593, 'Structural Engineer', True)), \
+             patch.object(svc, '_should_skip_candidate', return_value=False), \
+             patch('screening.detection._screening_skip_human_owned', return_value=True), \
+             patch('screening.detection._parse_api_user_ids_for_screening',
+                   return_value=[1147490]):
+            with app.app_context():
+                result = svc.detect_indeed_applicants()
+
+        assert result == []


### PR DESCRIPTION
## Summary
- **Root cause:** Native Indeed Apply (Plan B live) creates Bullhorn candidates as New Lead + Unassigned + source `Indeed` with a JobSubmission, but never creates a ParsedEmail and never sets Online Applicant — so Scout never discovered them. LinkedIn Job Board applicants still go through email inbound → Online Applicant → screened.
- **Fix:** Add `detect_indeed_applicants` (source-based Lucene + JobSubmission gate + Unassigned-eligible human-owner skip), merge into the 1-minute vetting cycle (Matador pattern). 120-minute lookback floor so sliding last-run watermark does not drop native applies.
- Evidence checked for IDs 4673692 / 4673695 (Indeed, no ParsedEmail/vetting_log) vs 4673694 (LinkedIn, screened).

## Test plan
- [x] Unit tests: Indeed submission gate + Unassigned pass + human-owner skip (`TestSubmissionGate`)
- [x] Cycle merge tests (`TestIndeedMerge`)
- [ ] After merge/deploy: confirm Railway logs show `🟢 Indeed applicant detected` for new Indeed New Leads
- [ ] Confirm SIVA (4673695) / ROBERT (4673692) get Scout notes if still inside the 120-min lookback (otherwise one-time re-screen)
- [ ] Confirm LinkedIn Online Applicant path unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Indeed Apply applicant detection to candidate vetting.
  * Includes recent applicants, job details, submission validation, duplicate prevention, and ownership handling.
  * Supports vetting cycles containing Indeed applicants alone or alongside email applicants.

* **Documentation**
  * Updated the README and candidate vetting documentation with Indeed, Pandologic, and Matador detection coverage.
  * Updated the documented version to 2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->