### PR TITLE
Reject job-title-as-name on inbound (#4673968)

### DIFF
--- a/.agents/memory/title-as-candidate-name.md
+++ b/.agents/memory/title-as-candidate-name.md
@@ -1,0 +1,14 @@
+---
+name: Title-as-candidate-name failure mode
+description: Apply-form / LinkedIn can submit occupation as first/last; inbound must prefer résumé AI name.
+---
+
+# Job title leaked into candidate name fields
+
+**Incident (2026-08-06):** Bullhorn #4673968. Apply form (`apply.myticas.com`, source LinkedIn) submitted `firstName=Senior`, `lastName=Business Analyst`. Subject became `… - Senior Business Analyst has applied on LinkedIn Job Board`. AI résumé parse correctly returned `Uday Vasireddy` + `current_title=Senior Business Analyst`, but inbound preferred email/subject name → Bullhorn created as "Senior Business Analyst".
+
+**Root cause (our bug, with bad form input):** email name preference over résumé AI, plus `is_valid_name` accepting title tokens. Resume and filename both had the real name.
+
+**Fix:** `is_job_title_phrase` + Title-Reject Guard (prefer résumé name; filename strips trailing title tokens; overwrite invalid names on recovery). Do not re-prefer email subject when it equals `current_title`.
+
+**Do not:** treat this as "corrupt resume" — résumé text and AI parse were fine.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,10 @@ Check dashboard for automation status:
 
 ## 📈 Recent Major Updates
 
+### August 2026: Reject job-title-as-name on inbound
+- **Problem**: LinkedIn apply-form submissions sometimes put the candidate's occupation in `firstName`/`lastName` (e.g. "Senior" / "Business Analyst"). Inbound preferred that email/subject name over the AI résumé parse, creating Bullhorn records with the title as the candidate name (e.g. #4673968 — real name Uday Vasireddy was on the résumé and in the filename).
+- **Fix**: `is_job_title_phrase` in `utils/candidate_name_extraction.py` (wired into `is_valid_name`), Title-Reject Guard in inbound processing (prefer résumé AI name; fall back to filename with title-suffix stripping), and overwrite (not `or`) when recovering over an invalid name.
+
 ### August 2026: Indeed native Apply Scout Screening coverage
 - **Problem**: Native Indeed Apply (Plan B) creates Bullhorn candidates as **New Lead + Unassigned + source Indeed** with a JobSubmission, but never creates a ParsedEmail and never sets status to Online Applicant — so Scout’s detectors never saw them (LinkedIn Job Board email inbound continued to screen normally).
 - **Fix**: `detect_indeed_applicants` in `screening/detection.py` — source-based Lucene search (`Indeed` / `Indeed Job Board`), JobSubmission gate, Unassigned-eligible human-owner skip, merged into the 1-minute vetting cycle (same pattern as Matador).

--- a/email_inbound_service/processing_mixin.py
+++ b/email_inbound_service/processing_mixin.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 from utils.candidate_name_extraction import (
     build_extraction_summary,
     is_cta_phrase,
+    is_job_title_phrase,
     is_valid_name,
     parse_name_from_email_address,
     parse_name_from_filename,
@@ -283,6 +284,43 @@ class ProcessingMixin:
                     first_name = None
                     last_name = None
 
+            # Title-Reject Guard: occupation / job-title leaked into the
+            # name fields (apply-form autofill, LinkedIn subject using
+            # headline, or email name == résumé current_title). Prefer
+            # the AI résumé name, then clear so filename / email-local
+            # recovery can run. Production: #4673968 "Senior Business
+            # Analyst" while résumé AI had "Uday Vasireddy".
+            current_title = (resume_data.get('current_title') or '').strip()
+            combined_name = f"{first_name or ''} {last_name or ''}".strip()
+            name_matches_title = bool(
+                combined_name
+                and current_title
+                and combined_name.lower() == current_title.lower()
+            )
+            if first_name and last_name and (
+                is_job_title_phrase(combined_name) or name_matches_title
+            ):
+                self.logger.warning(
+                    f"Title-style name rejected: '{combined_name}' "
+                    f"(matches_title={name_matches_title}). Trying resume_data "
+                    f"alone, then falling to recovery layers."
+                )
+                rd_first = resume_data.get('first_name')
+                rd_last = resume_data.get('last_name')
+                if (rd_first and rd_last
+                        and not is_job_title_phrase(f"{rd_first} {rd_last}")
+                        and is_valid_name(rd_first, rd_last)
+                        and f"{rd_first} {rd_last}".strip().lower() != current_title.lower()):
+                    first_name, last_name = rd_first, rd_last
+                    parsed_email.candidate_name = f"{first_name} {last_name}".strip()
+                    self.logger.info(
+                        f"Title-Reject Guard recovered name from resume_data: "
+                        f"{first_name} {last_name}"
+                    )
+                else:
+                    first_name = None
+                    last_name = None
+
             has_name = is_valid_name(first_name, last_name)
             has_contact = bool(candidate_email or candidate_phone)
             has_email_data = bool(email_candidate.get('first_name') or email_candidate.get('email'))
@@ -294,8 +332,10 @@ class ProcessingMixin:
                         f"Layer 3 (filename) recovered name: {fn_first} {fn_last} "
                         f"from '{parsed_email.resume_filename}'"
                     )
-                    first_name = first_name or fn_first
-                    last_name = last_name or fn_last
+                    # Overwrite — do not keep a truthy-but-poisoned
+                    # first/last via `or` (we only enter this block when
+                    # the current pair failed is_valid_name).
+                    first_name, last_name = fn_first, fn_last
                     parsed_email.candidate_name = f"{first_name} {last_name}".strip()
                     has_name = True
 
@@ -305,8 +345,7 @@ class ProcessingMixin:
                     self.logger.info(
                         f"Layer 3b (email local-part) recovered name: {ea_first} {ea_last}"
                     )
-                    first_name = first_name or ea_first
-                    last_name = last_name or ea_last
+                    first_name, last_name = ea_first, ea_last
                     parsed_email.candidate_name = f"{first_name} {last_name}".strip()
                     has_name = True
 

--- a/tests/test_email_inbound_extraction.py
+++ b/tests/test_email_inbound_extraction.py
@@ -13,6 +13,7 @@ import pytest
 
 from utils.candidate_name_extraction import (
     extract_name_from_pattern,
+    is_job_title_phrase,
     is_valid_name,
     is_valid_name_token,
     merge_name_candidates,
@@ -153,6 +154,19 @@ class TestParseNameFromFilename:
         assert first == "Mary-Jane"
         assert last == "O'Brien"
 
+    def test_strips_trailing_job_title_suffix(self):
+        """Name + occupation suffix must yield the person, not the title."""
+        first, last = parse_name_from_filename(
+            "Uday_Vasireddy_Senior_Business_Analyst.docx"
+        )
+        assert (first, last) == ("Uday", "Vasireddy")
+        assert is_valid_name(first, last)
+
+    def test_title_only_filename_rejected(self):
+        """A resume named only after the occupation must not invent a name."""
+        assert parse_name_from_filename("Senior_Business_Analyst.docx") == (None, None)
+        assert parse_name_from_filename("Business_Analyst_Resume.pdf") == (None, None)
+
 
 # ---------------------------------------------------------------------------
 # parse_name_from_email_address — Layer 3b fallback
@@ -208,6 +222,120 @@ class TestIsValidName:
 
     def test_hyphenated_passes(self):
         assert is_valid_name("Mary-Jane", "O'Brien")
+
+    def test_job_title_as_name_rejected(self):
+        """REGRESSION #4673968: occupation must not pass as a person name."""
+        assert not is_valid_name("Senior", "Business Analyst")
+        assert not is_valid_name("Business", "Analyst")
+        assert not is_valid_name("Software", "Engineer")
+        assert not is_valid_name("Product", "Manager")
+
+    def test_real_surname_senior_still_accepted(self):
+        assert is_valid_name("John", "Senior")
+
+
+# ---------------------------------------------------------------------------
+# is_job_title_phrase — rejects occupation leaked into name fields
+# ---------------------------------------------------------------------------
+class TestIsJobTitlePhrase:
+    """REGRESSION: Bullhorn #4673968 — apply form sent firstName=Senior /
+    lastName=Business Analyst; AI résumé parse had Uday Vasireddy but
+    email-subject preference won."""
+
+    def test_production_senior_business_analyst(self):
+        assert is_job_title_phrase("Senior Business Analyst") is True
+        assert is_valid_name("Senior", "Business Analyst") is False
+
+    def test_common_titles(self):
+        for title in (
+            "Business Analyst",
+            "Software Engineer",
+            "Senior Software Engineer",
+            "Product Manager",
+            "Data Scientist",
+            "Lead Data Engineer",
+        ):
+            assert is_job_title_phrase(title) is True, title
+
+    def test_incomplete_title_remnant(self):
+        """After stripping a role word, seniority+domain must still reject."""
+        assert is_job_title_phrase("Senior Business") is True
+        assert is_valid_name("Senior", "Business") is False
+
+    def test_real_name_not_rejected(self):
+        assert is_job_title_phrase("Uday Vasireddy") is False
+        assert is_valid_name("Uday", "Vasireddy") is True
+
+    def test_surname_senior_still_allowed(self):
+        """'John Senior' is a plausible real name — seniority as last only."""
+        assert is_job_title_phrase("John Senior") is False
+        assert is_valid_name("John", "Senior") is True
+
+    def test_empty_rejected(self):
+        assert is_job_title_phrase("") is False
+        assert is_job_title_phrase(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Title-Reject Guard — #4673968 Uday Vasireddy regression
+# ---------------------------------------------------------------------------
+class TestTitleRejectGuardRegression:
+    """Pins the Aug 2026 production failure.
+
+    Apply-form / LinkedIn subject preferred firstName='Senior' /
+    lastName='Business Analyst' (the candidate's occupation) over the
+    AI résumé name 'Uday Vasireddy'. Bullhorn candidate #4673968 was
+    created with the title as the person name.
+
+    Verdict from investigate: email-subject / form name won the
+    ``email_candidate or resume_data`` preference; ``is_valid_name``
+    accepted alphabetic title tokens; recovery layers used ``or`` and
+    could not overwrite a truthy poisoned pair. Fix: reject
+    title-shaped pairs, prefer resume AI name, then filename / email.
+    """
+
+    EMAIL_FIRST = "Senior"
+    EMAIL_LAST = "Business Analyst"
+    RESUME_FIRST = "Uday"
+    RESUME_LAST = "Vasireddy"
+    CURRENT_TITLE = "Senior Business Analyst"
+    FILENAME = "Uday_Vasireddy_Senior_Business_Analyst.docx"
+    EMAIL = "uday.vasireddy@example.com"
+
+    def test_poisoned_email_name_fails_validator(self):
+        assert not is_valid_name(self.EMAIL_FIRST, self.EMAIL_LAST)
+
+    def test_resume_ai_name_passes_validator(self):
+        assert is_valid_name(self.RESUME_FIRST, self.RESUME_LAST)
+
+    def test_name_equals_current_title(self):
+        combined = f"{self.EMAIL_FIRST} {self.EMAIL_LAST}"
+        assert combined.lower() == self.CURRENT_TITLE.lower()
+        assert is_job_title_phrase(combined)
+
+    def test_filename_recovers_person_not_title(self):
+        first, last = parse_name_from_filename(self.FILENAME)
+        assert (first, last) == ("Uday", "Vasireddy")
+
+    def test_email_local_part_recovers_person(self):
+        first, last = parse_name_from_email_address(self.EMAIL)
+        assert (first, last) == ("Uday", "Vasireddy")
+
+    def test_deterministic_layers_prefer_resume_over_title(self):
+        """Simulate Title-Reject Guard: drop title pair, keep résumé name."""
+        first, last = self.EMAIL_FIRST, self.EMAIL_LAST
+        if is_job_title_phrase(f"{first} {last}"):
+            first, last = self.RESUME_FIRST, self.RESUME_LAST
+        assert is_valid_name(first, last)
+        assert (first, last) == ("Uday", "Vasireddy")
+
+    def test_merge_skips_title_picks_resume(self):
+        winner = merge_name_candidates(
+            (self.EMAIL_FIRST, self.EMAIL_LAST),
+            (self.RESUME_FIRST, self.RESUME_LAST),
+            parse_name_from_filename(self.FILENAME),
+        )
+        assert winner == ("Uday", "Vasireddy")
 
 
 # ---------------------------------------------------------------------------

--- a/utils/candidate_name_extraction.py
+++ b/utils/candidate_name_extraction.py
@@ -157,6 +157,81 @@ CTA_PHRASES = {
     "scout genius",
 }
 
+# Job-title vocabulary. Production failure (2026-08-06): LinkedIn apply-form
+# submitted firstName="Senior" / lastName="Business Analyst" (the candidate's
+# occupation) while the résumé AI correctly extracted "Uday Vasireddy". Email
+# subject preference then shipped the title to Bullhorn as the candidate name
+# (#4673968). These tokens/phrases reject title-shaped (first, last) pairs
+# without blocking rare real surnames like "Senior" alone ("John Senior").
+JOB_TITLE_SENIORITY_TOKENS = {
+    "senior", "junior", "principal", "staff", "lead", "sr", "jr",
+    "associate", "entry", "mid", "midlevel", "mid-level",
+}
+
+JOB_TITLE_ROLE_TOKENS = {
+    "analyst", "engineer", "developer", "manager", "architect",
+    "consultant", "specialist", "director", "coordinator",
+    "administrator", "admin", "officer", "designer", "scientist",
+    "programmer", "technician", "recruiter", "accountant",
+    "executive", "president", "founder", "intern", "trainee",
+    "assistant", "supervisor", "strategist", "owner", "lead",
+    "sme", "ba", "pm", "po", "qa", "sdet", "devops",
+}
+
+JOB_TITLE_DOMAIN_TOKENS = {
+    "business", "software", "data", "product", "project", "systems",
+    "system", "network", "cloud", "full", "stack", "fullstack",
+    "frontend", "backend", "front", "back", "end", "ux", "ui",
+    "technical", "tech", "sales", "marketing", "finance",
+    "financial", "operations", "ops", "security", "cyber",
+    "machine", "learning", "web", "mobile", "platform",
+    "infrastructure", "solutions", "solution", "enterprise",
+    "digital", "information", "quality", "assurance", "scrum",
+    "agile", "delivery", "program", "portfolio", "release",
+    "site", "reliability", "sre", "database", "warehouse",
+}
+
+# Exact / near-exact multi-word titles commonly pasted into name fields.
+JOB_TITLE_PHRASES = {
+    "business analyst",
+    "senior business analyst",
+    "junior business analyst",
+    "software engineer",
+    "senior software engineer",
+    "software developer",
+    "senior software developer",
+    "product manager",
+    "senior product manager",
+    "project manager",
+    "senior project manager",
+    "product owner",
+    "technical product owner",
+    "scrum master",
+    "data scientist",
+    "data engineer",
+    "data analyst",
+    "devops engineer",
+    "site reliability engineer",
+    "solutions architect",
+    "solution architect",
+    "technical architect",
+    "qa engineer",
+    "quality assurance",
+    "full stack developer",
+    "fullstack developer",
+    "front end developer",
+    "frontend developer",
+    "back end developer",
+    "backend developer",
+    "program manager",
+    "engineering manager",
+    "account manager",
+    "sales manager",
+    "hr manager",
+    "recruiter",
+    "talent acquisition",
+}
+
 
 def is_cta_phrase(text: Optional[str]) -> bool:
     """Return True if ``text`` is a job-board call-to-action phrase.
@@ -180,6 +255,57 @@ def is_cta_phrase(text: Optional[str]) -> bool:
         if phrase in normalised:
             return True
     return False
+
+
+def is_job_title_phrase(text: Optional[str]) -> bool:
+    """Return True if ``text`` looks like a job title rather than a person name.
+
+    Production failure: apply-form / LinkedIn subject used the candidate's
+    occupation ("Senior Business Analyst") where first/last name belong.
+    ``is_valid_name`` previously accepted those tokens because they are
+    alphabetic and title-cased.
+
+    Match layers (any hit → True):
+
+    1. Exact / substring hit against :data:`JOB_TITLE_PHRASES`.
+    2. First token is seniority (``Senior``, ``Lead``, …) AND any later
+       token is a role (``Analyst``, ``Engineer``, …).
+    3. Every token (2+) is in the union of seniority / role / domain
+       title vocabulary (e.g. ``Business Analyst``, ``Senior Business``
+       after a role word was stripped). Bare ``John Senior`` still
+       passes because ``John`` is not title vocabulary.
+    """
+    if not text:
+        return False
+    normalised = " ".join(text.strip().lower().split())
+    if not normalised:
+        return False
+    for phrase in JOB_TITLE_PHRASES:
+        if phrase == normalised or f" {phrase} " in f" {normalised} ":
+            return True
+        if normalised.startswith(phrase + " ") or normalised.endswith(" " + phrase):
+            return True
+
+    tokens = [t.strip(".,;:") for t in re.split(r"[\s\-]+", normalised) if t.strip(".,;:")]
+    if len(tokens) < 2:
+        return False
+
+    title_vocab = (
+        JOB_TITLE_SENIORITY_TOKENS
+        | JOB_TITLE_ROLE_TOKENS
+        | JOB_TITLE_DOMAIN_TOKENS
+    )
+    if tokens[0] in JOB_TITLE_SENIORITY_TOKENS and any(
+        t in JOB_TITLE_ROLE_TOKENS for t in tokens[1:]
+    ):
+        return True
+    # All-vocab pairs catch incomplete titles ("Senior Business") and
+    # domain+role titles ("Business Analyst") without requiring a role
+    # token — real surnames like "John Senior" stay allowed.
+    if all(t in title_vocab for t in tokens):
+        return True
+    return False
+
 
 NAME_TOKEN_RE = r"[A-Za-z][A-Za-z'\-]*"
 # Non-greedy multi-token name capture so trailing suffix anchors match
@@ -276,6 +402,13 @@ def is_valid_name(first_name: Optional[str], last_name: Optional[str]) -> bool:
     # extractor and committed to Bullhorn as firstName="Invite" /
     # lastName="Friend" for two real candidates.
     if is_cta_phrase(combined):
+        return False
+
+    # Reject job-title-shaped pairs ("Senior Business Analyst",
+    # "Software Engineer"). Production failure: apply-form submitted
+    # occupation as first/last and inbound preferred the email subject
+    # over the AI résumé name (#4673968 Uday Vasireddy).
+    if is_job_title_phrase(combined):
         return False
 
     # Validate first name: must be a single valid token
@@ -475,6 +608,23 @@ def parse_name_from_filename(filename: str) -> Tuple[Optional[str], Optional[str
     if not filtered:
         return None, None
 
+    # Strip trailing job-title tokens so filenames like
+    # "Uday_Vasireddy_Senior_Business_Analyst.docx" yield the person
+    # name rather than absorbing the occupation suffix into last_name.
+    # Continue while len > 1 so a title-only filename
+    # ("Senior_Business_Analyst.docx") collapses to a mononym / empty
+    # rather than leaving the remnant pair "Senior Business".
+    title_vocab = (
+        JOB_TITLE_SENIORITY_TOKENS
+        | JOB_TITLE_ROLE_TOKENS
+        | JOB_TITLE_DOMAIN_TOKENS
+    )
+    while len(filtered) > 1 and filtered[-1].lower().strip("()[]{}") in title_vocab:
+        filtered.pop()
+
+    if not filtered:
+        return None, None
+
     candidate = " ".join(filtered)
     first, last = split_full_name(candidate)
 
@@ -483,6 +633,15 @@ def parse_name_from_filename(filename: str) -> Tuple[Optional[str], Optional[str
     if first and first.lower() in INVALID_NAME_TOKENS:
         return None, None
     if last and last.split()[0].lower() in INVALID_NAME_TOKENS:
+        return None, None
+
+    # Reject when the remaining (first, last) is still a job title
+    # (e.g. filename was only "Senior_Business_Analyst.docx").
+    if first and last and is_job_title_phrase(f"{first} {last}"):
+        return None, None
+    # Title-only filenames that collapsed to a single seniority/role
+    # token (mononym) are not usable person names.
+    if first and not last and first.lower() in title_vocab:
         return None, None
 
     return first, last


### PR DESCRIPTION
## Summary
- **Verdict:** our bug (with bad apply-form input). Résumé AI correctly extracted Uday Vasireddy; inbound preferred email/subject name `Senior Business Analyst`.
- Reject title-shaped `(first, last)` pairs via `is_job_title_phrase`, Title-Reject Guard prefers résumé AI name, filename strips occupation suffixes.
- Regression tests for Bullhorn #4673968; README updated.

## Evidence
- Form: `firstName=Senior`, `lastName=Business Analyst`
- Subject: `… - Senior Business Analyst has applied on LinkedIn Job Board`
- Logs: `AI parsed resume successfully: Uday Vasireddy` then `Validation passed: name=Senior Business Analyst`
- ParsedEmail 36452 / candidate [Senior Business Analyst](https://cls45.bullhornstaffing.com/BullhornStaffing/OpenWindow.cfm?Entity=Candidate&id=4673968)

## Test plan
- [x] `pytest tests/test_email_inbound_extraction.py tests/test_resume_name_extraction.py` (131 passed)
- [ ] After merge/deploy: new LinkedIn apply with title-as-name should create correct person name
- [ ] Manually rename Bullhorn #4673968 → Uday / Vasireddy (not auto-patched; confirm if desired)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved candidate-name detection to prevent job titles, such as “Senior Business Analyst,” from being recorded as names.
  - Candidate names are now recovered more reliably from résumés, filenames, or email details when invalid values are detected.
  - Filenames with trailing job titles are cleaned, while title-only filenames are rejected.
  - Preserved legitimate names containing words that may also appear in job titles.

- **Documentation**
  - Added guidance on candidate-name validation and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->